### PR TITLE
fix 400 error.

### DIFF
--- a/flask/api/login.py
+++ b/flask/api/login.py
@@ -23,8 +23,8 @@ class SignIn(Resource):
 
     def post(self):
         parser = reqparse.RequestParser()
-        parser.add_argument('code', required=True)
-        parser.add_argument('state', required=True)
+        parser.add_argument('code', required=True, location='args')
+        parser.add_argument('state', required=True, location='args')
         args = parser.parse_args()
         code = args['code']
         state = args['state']


### PR DESCRIPTION
werkzeug.exceptions.BadRequest: 400 Bad Request: The browser (or proxy) sent a request that this server could not understand.